### PR TITLE
[22-02-19] search 화면 구현 완 (#2)

### DIFF
--- a/가사오케/GasaOK/Base.lproj/Main.storyboard
+++ b/가사오케/GasaOK/Base.lproj/Main.storyboard
@@ -137,14 +137,14 @@
                         <viewLayoutGuide key="safeArea" id="Obj-RH-9U9"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
-                    <navigationItem key="navigationItem" id="e3P-sF-5eG"/>
+                    <navigationItem key="navigationItem" title="검색" id="e3P-sF-5eG"/>
                     <connections>
                         <outlet property="searchTableView" destination="FBP-uR-mwq" id="Sl9-R7-WDa"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="52I-Uy-g7Q" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2496.9230769230767" y="-248.10426540284359"/>
+            <point key="canvasLocation" x="2460" y="-248"/>
         </scene>
         <!--가사 정보-->
         <scene sceneID="KdN-Al-XsU">
@@ -300,7 +300,6 @@
                     </navigationBar>
                     <nil name="viewControllers"/>
                     <connections>
-
                         <segue destination="HiZ-Tf-KUE" kind="relationship" relationship="rootViewController" id="6C7-31-Aiw"/>
                     </connections>
                 </navigationController>

--- a/가사오케/GasaOK/Model/searchResultDummy.swift
+++ b/가사오케/GasaOK/Model/searchResultDummy.swift
@@ -17,4 +17,8 @@ let searchResultDummy = [
     SongInfo(songName: "우리가 헤어져야 했던 이유", singerName: "비비", karaokeNumber: "56713", lryics: nil, karaokeType: .KY),
     SongInfo(songName: "나무", singerName: "카더가든", karaokeNumber: "69031", lryics: nil, karaokeType: .KY),
     SongInfo(songName: "이별후회", singerName: "김나영", karaokeNumber: "78942", lryics: nil, karaokeType: .KY),
+    SongInfo(songName: "위잉위잉", singerName: "혁오", karaokeNumber: "ky", lryics: nil, karaokeType: .KY),
+    SongInfo(songName: "혁오", singerName: "위잉위잉", karaokeNumber: "tj", lryics: nil, karaokeType: .TJ),
+    SongInfo(songName: "혁오", singerName: "위잉위잉----tj", karaokeNumber: "tj", lryics: nil, karaokeType: .TJ),
+    SongInfo(songName: "혁오", singerName: "위잉위잉----ky", karaokeNumber: "ky", lryics: nil, karaokeType: .KY),
 ]


### PR DESCRIPTION
# search 화면 구현 완 (#2)

## 작업사항
* searchVC 함수들 주석으로 정리
* 가수 및 노래 동시에 검색 가능
* 검색 결과는 TJ와 KY로 구분해서 화면 출력(segmented Control)
* 그 외 (#10)

## 주의사항
* 더미데이터를 이용함
* API 요청 결과에 따라 코드 구성이 달라질 수 있음