### PR TITLE
[2022-02-23] 네비게이션바 백버튼, 탭바 숨김 이슈 해결(#23)

### DIFF
--- a/가사오케/GasaOK.xcodeproj/project.pbxproj
+++ b/가사오케/GasaOK.xcodeproj/project.pbxproj
@@ -114,9 +114,7 @@
 				6802ABC127BBC2A600BC6243 /* hotSongDummy.swift */,
 				6802ABC327BBC2C200BC6243 /* SongInfo.swift */,
 				689B67C527BE4C3D0062D0F8 /* searchResultDummy.swift */,
-
 				68297D8427C288CE0073F5F6 /* folderDummy.swift */,
-
 				6F4BC00127C1598B0076E04C /* mySongDummy.swift */,
 			);
 			path = Model;
@@ -133,13 +131,10 @@
 				686D808827BCEEA0005975F7 /* SettingsVC.swift */,
 				6802ABBE27BB85BD00BC6243 /* SearchVC.swift */,
 				6802ABC527BBCEE500BC6243 /* SearchTableViewCell.swift */,
-
 				68297D7E27C269920073F5F6 /* DarkModeTableViewCell.swift */,
 				68297D8027C26A170073F5F6 /* FolderPositionChangeTableViewCell.swift */,
 				68297D8227C26A7D0073F5F6 /* FolderAddTableViewCell.swift */,
-
 				6F4BC00327C164D10076E04C /* MySongTableViewCell.swift */,
-
 			);
 			path = Controller;
 			sourceTree = "<group>";

--- a/가사오케/GasaOK/Base.lproj/Main.storyboard
+++ b/가사오케/GasaOK/Base.lproj/Main.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="TlX-OQ-W2a">
-    <device id="retina6_7" orientation="portrait" appearance="light"/>
+    <device id="retina6_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
@@ -13,7 +13,7 @@
             <objects>
                 <viewController storyboardIdentifier="homeVC" title="Home View Contoller" id="BYZ-38-t0r" customClass="ViewController" customModule="GasaOK" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="428" height="926"/>
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="65" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="Sn0-VT-suQ">
@@ -104,7 +104,7 @@
             <objects>
                 <viewController title="Statistics View Controller" id="HnJ-Yw-nR1" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="IyQ-0b-C4A">
-                        <rect key="frame" x="0.0" y="0.0" width="428" height="926"/>
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <viewLayoutGuide key="safeArea" id="L38-Rg-hW3"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -120,7 +120,7 @@
             <objects>
                 <viewController title="Change Folder Floating VC" id="khy-Uk-KxI" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="h5u-17-lR7">
-                        <rect key="frame" x="0.0" y="0.0" width="428" height="926"/>
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <viewLayoutGuide key="safeArea" id="qCp-g9-qtW"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -135,7 +135,7 @@
             <objects>
                 <viewController storyboardIdentifier="SearchVC" title="Search View Controller" id="HiZ-Tf-KUE" customClass="SearchVC" customModule="GasaOK" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="pB3-su-BLG">
-                        <rect key="frame" x="0.0" y="0.0" width="428" height="926"/>
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="65" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="FBP-uR-mwq">
@@ -224,9 +224,9 @@
         <!--가사 정보-->
         <scene sceneID="KdN-Al-XsU">
             <objects>
-                <viewController id="0Ij-zj-KDV" customClass="SongInfoDetailVC" customModule="GasaOK" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController hidesBottomBarWhenPushed="YES" id="0Ij-zj-KDV" customClass="SongInfoDetailVC" customModule="GasaOK" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="7UF-xQ-Q2M">
-                        <rect key="frame" x="0.0" y="0.0" width="428" height="926"/>
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="SongName" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="t6T-an-dRq">
@@ -238,23 +238,23 @@
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="singername" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="L8W-L5-WaG">
                                 <rect key="frame" x="29.999999999999993" y="149.33333333333334" width="94.333333333333314" height="21.666666666666657"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="18"/>
-                                <nil key="textColor"/>
+                                <color key="textColor" systemColor="systemGray2Color"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Number" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hhf-6H-OGG">
-                                <rect key="frame" x="333" y="181" width="65" height="22"/>
+                                <rect key="frame" x="295" y="181" width="65" height="22"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="18"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="music.note" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="IJ9-VP-yD3">
-                                <rect key="frame" x="316.66666666666674" y="182" width="14.333333333333314" height="18.999999999999986"/>
+                                <rect key="frame" x="278.66666666666669" y="182" width="14.333333333333314" height="18.999999999999986"/>
                             </imageView>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="03S-ho-cjS">
-                                <rect key="frame" x="20" y="223" width="388" height="643"/>
+                                <rect key="frame" x="20" y="223" width="350" height="561"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ZwS-bY-Enb">
-                                        <rect key="frame" x="0.0" y="0.0" width="388" height="692.66666666666663"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="350" height="692.66666666666663"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2nO-iM-JmV">
                                                 <rect key="frame" x="5" y="5" width="335" height="682.66666666666663"/>
@@ -331,20 +331,21 @@
                     <navigationItem key="navigationItem" title="가사 정보" id="jUu-D2-pL3"/>
                     <connections>
                         <outlet property="karaokaNumberLabel" destination="hhf-6H-OGG" id="5W9-i4-CkT"/>
+                        <outlet property="lyricsLabel" destination="2nO-iM-JmV" id="IUd-pb-Kof"/>
                         <outlet property="singerNameLabel" destination="L8W-L5-WaG" id="LJG-xs-u4Q"/>
                         <outlet property="songNameLabel" destination="t6T-an-dRq" id="Eew-3G-woW"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ynh-Ta-1ZJ" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="3061.5384615384614" y="-248.10426540284359"/>
+            <point key="canvasLocation" x="3456" y="-248"/>
         </scene>
         <!--Song Info Detail VC-->
         <scene sceneID="GkW-xO-BQG">
             <objects>
                 <viewController title="Song Info Detail VC" id="hOl-jS-CoC" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="3Ar-jT-bHp">
-                        <rect key="frame" x="0.0" y="0.0" width="428" height="926"/>
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <viewLayoutGuide key="safeArea" id="iqR-HG-2vn"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -359,7 +360,7 @@
             <objects>
                 <viewController storyboardIdentifier="SettingsViewController" title="Settings View Controller" id="cEN-m0-sXn" customClass="SettingsVC" customModule="GasaOK" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="h57-68-4q4">
-                        <rect key="frame" x="0.0" y="0.0" width="428" height="926"/>
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="insetGrouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" estimatedSectionHeaderHeight="-1" sectionFooterHeight="18" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="sdu-x2-GAV">
@@ -509,7 +510,7 @@
             <objects>
                 <viewController title="Rename Folder VC" id="ST7-dS-6wK" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="HLd-8r-CJP">
-                        <rect key="frame" x="0.0" y="0.0" width="428" height="926"/>
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <viewLayoutGuide key="safeArea" id="WOs-Bw-lGC"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -549,7 +550,7 @@
                     <tabBarItem key="tabBarItem" title="보관함" image="folder.fill" catalog="system" id="GaA-co-QII"/>
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="Swy-YB-iTE">
-                        <rect key="frame" x="0.0" y="44" width="428" height="44"/>
+                        <rect key="frame" x="0.0" y="44" width="390" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -568,7 +569,7 @@
                     <tabBarItem key="tabBarItem" title="검색" image="magnifyingglass" catalog="system" selectedImage="magnifyingglass" id="slI-LR-9ql"/>
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="NOE-6n-3uS">
-                        <rect key="frame" x="0.0" y="44" width="428" height="44"/>
+                        <rect key="frame" x="0.0" y="44" width="390" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>

--- a/가사오케/GasaOK/Controller/SearchVC.swift
+++ b/가사오케/GasaOK/Controller/SearchVC.swift
@@ -27,6 +27,7 @@ class SearchVC: UIViewController, UITableViewDelegate, UITableViewDataSource, UI
         hotSongScopeBarSetUp()
 
         searchControllerDelegate()
+        barButtonItemTextRemove()
     }
     
     // MARK: - set up
@@ -220,6 +221,11 @@ class SearchVC: UIViewController, UITableViewDelegate, UITableViewDataSource, UI
         }
         
         
+    }
+    
+    func barButtonItemTextRemove() {
+        let backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: self, action: nil)
+        self.navigationItem.backBarButtonItem = backBarButtonItem
     }
     
    

--- a/가사오케/GasaOK/Controller/SongInfoDetailVC.swift
+++ b/가사오케/GasaOK/Controller/SongInfoDetailVC.swift
@@ -14,30 +14,17 @@ class SongInfoDetailVC: UIViewController {
     @IBOutlet weak var songNameLabel: UILabel!
     @IBOutlet weak var singerNameLabel: UILabel!
     @IBOutlet weak var karaokaNumberLabel: UILabel!
+    @IBOutlet weak var lyricsLabel: UILabel!
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        // nav bar 가사 화면 네이비게이션 뒤로가기버튼 설정
-        self.navigationController?.navigationBar.topItem?.title = ""
-        // 가사 상세 보기화면에서 탭 숨기기
-        self.tabBarController?.tabBar.isHidden = true
-        // Do any additional setup after loading the view.
+        songInfodidshow()
+    }
+    
+    func songInfodidshow() {
         songNameLabel.text = songDetailData.songName
         singerNameLabel.text = songDetailData.singerName
         karaokaNumberLabel.text = songDetailData.karaokeNumber
-        
     }
-    
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
-    }
-    */
 
 }


### PR DESCRIPTION
# [검색창—노래 정보 화면] 네비게이션바 백버튼, 탭바 숨김 이슈 해결(#23)

## 네비게이션바 백버튼
* 노래 정보 화면에서 백버튼의 텍스트를 제거함

## 탭바
* 노래 정보 화면에서는 탭바가 보일 필요가 없으므로 화면이 나타날때 Hide시켜줌